### PR TITLE
[Login] Check if user is logged in upon entering foreground

### DIFF
--- a/Readr/Readr/Controllers/View Controllers/AppleIDViewController.swift
+++ b/Readr/Readr/Controllers/View Controllers/AppleIDViewController.swift
@@ -9,38 +9,48 @@
 import UIKit
 
 class AppleIDViewController: UIViewController {
-    
-    @IBOutlet weak var iCloudStackView: UIStackView!
-    
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        iCloudStackView.isHidden = true
-        //fetchAppleUser()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(true)
-        fetchAppleUser()
-    }
-    
-    func fetchAppleUser() {
-        UserController.shared.fetchAppleUserReference { (result) in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(_):
-                    self.presentLoginVC()
-                case .failure(_):
-                    self.iCloudStackView.isHidden = false
-                }
-            }
+
+  @IBOutlet weak var iCloudStackView: UIStackView!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    iCloudStackView.isHidden = true
+    //fetchAppleUser()
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+
+    NotificationCenter.default.removeObserver(self)
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(true)
+    fetchAppleUser()
+
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(fetchAppleUser),
+      name: UIApplication.willEnterForegroundNotification, object: nil)
+  }
+
+  @objc func fetchAppleUser() {
+    UserController.shared.fetchAppleUserReference { (result) in
+      DispatchQueue.main.async {
+        switch result {
+        case .success(_):
+          self.presentLoginVC()
+        case .failure(_):
+          self.iCloudStackView.isHidden = false
         }
+      }
     }
-    
-    func presentLoginVC() {
-        let logIn = UIStoryboard(name: "LogIn", bundle: nil).instantiateViewController(withIdentifier: "LoginVC")
-        logIn.modalPresentationStyle = .fullScreen
-        self.present(logIn, animated: true, completion: nil)
-    }
-    
-} //End of class
+  }
+
+  func presentLoginVC() {
+    let logIn = UIStoryboard(name: "LogIn", bundle: nil)
+      .instantiateViewController(withIdentifier: "LoginVC")
+    logIn.modalPresentationStyle = .fullScreen
+    self.present(logIn, animated: true, completion: nil)
+  }
+
+}  //End of class


### PR DESCRIPTION
We ask the user to log in if they aren't and tell them to exit the app.
If they minimize it, log in and come back we should check if they are
logged in instead of silently failing and requiring them to force close
the app.