### PR TITLE
Always setValue for the pastReads key even if the array is empty

### DIFF
--- a/Readr/Readr/Models/Bookclub.swift
+++ b/Readr/Readr/Models/Bookclub.swift
@@ -95,9 +95,7 @@ extension CKRecord {
             BookclubConstants.meetingInfoKey : bookclub.meetingInfo,
             BookclubConstants.memberCapacityKey : bookclub.memberCapacity
         ])
-        if bookclub.pastReads.count > 0 {
-            self.setValue(bookclub.pastReads, forKey: BookclubConstants.pastReadsKey)
-               }
+        self.setValue(bookclub.pastReads, forKey: BookclubConstants.pastReadsKey)
         if let photoAsset = bookclub.photoAsset {
             self.setValue(photoAsset, forKey: BookclubConstants.photoAssetKey)
         }


### PR DESCRIPTION
This had been set to only update if the array wasn't empty. But if we
are removing the last book this code doesn't make sense and we will
fail to actually update our bookclub.